### PR TITLE
Filter out broken symlinks

### DIFF
--- a/wes/framework_plugins/plugin_django.py
+++ b/wes/framework_plugins/plugin_django.py
@@ -32,6 +32,8 @@ class CustomFramework(Framework):
         glob_path = os.path.join(self.working_dir, '**', '*.py')
         files = glob.glob(glob_path, recursive=True)
 
+        files = list(filter(lambda x: os.path.isfile(x), files))
+
         # if there aren't any *.py files then it's not a django project
         if not files:
             return False


### PR DESCRIPTION
Broken symlinks within a Python project results in the following error:
`FileNotFoundError: [Errno 2] No such file or directory: 'code.py'`

This pull request filters out missing files using the following logic:
`files = list(filter(lambda x: os.path.isfile(x), files))`